### PR TITLE
Don't just use StatsD on live

### DIFF
--- a/lib/mozart/logger.rb
+++ b/lib/mozart/logger.rb
@@ -19,7 +19,7 @@ module Mozart
     end
 
     def self.metric_driver(opts)
-      return statsd_driver(opts[:statsd])  if opts[:statsd]     && production?
+      return statsd_driver(opts[:statsd])  if opts[:statsd]
       cloudwatch_driver(opts[:cloudwatch]) if opts[:cloudwatch] && production?
     end
 


### PR DESCRIPTION
![](http://0.media.collegehumor.cvcdn.com/81/45/582ff0263877b8778f0ead56c08c2510-satisfying17.gif)

With StatsD aggregating our metrics we don't need to economise so much. This enables the StatsD driver on all environments, not just live.
